### PR TITLE
Make the python version configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ env:
   global:
     - REPOSITORY=osism/openstackclient
   matrix:
-    - VERSION=latest
-    - VERSION=rocky
-    - VERSION=stein
-    - VERSION=train
+    - VERSION=latest PYTHON_VERSION=3.7
+    - VERSION=rocky PYTHON_VERSION=3.6
+    - VERSION=stein PYTHON_VERSION=3.7
+    - VERSION=train PYTHON_VERSION=3.7
 
 before_script:
   - bash scripts/lint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.7-alpine
+ARG PYTHON_VERSION=3.7
+FROM python:${PYTHON_VERSION}-alpine
 
 ARG VERSION=latest
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,6 +6,7 @@ set -x
 # Available environment variables
 #
 # BUILD_OPTS
+# PYTHON_VERSION
 # REPOSITORY
 # VERSION
 
@@ -13,10 +14,12 @@ set -x
 
 BUILD_OPTS=${BUILD_OPTS:-}
 CREATED=$(date --rfc-3339=ns)
+PYTHON_VERSION=${PYTHON_VERSION:-3.7}
 REVISION=$(git rev-parse --short HEAD)
 VERSION=${VERSION:-latest}
 
 docker build \
+    --build-arg "PYTHON_VERSION=$PYTHON_VERSION" \
     --build-arg "VERSION=$VERSION" \
     --tag "$REPOSITORY:$VERSION" \
     --label "org.opencontainers.image.created=$CREATED" \


### PR DESCRIPTION
Python 3.6 is necessary for Rocky because of "issubclass() arg 1 must be a class".